### PR TITLE
Unsigned 0 fixes warning check_valid_size hex2bin

### DIFF
--- a/sodiumpp/include/sodiumpp/sodiumpp.h
+++ b/sodiumpp/include/sodiumpp/sodiumpp.h
@@ -55,7 +55,9 @@ namespace sodiumpp {
 
 // for testing against errors:
 template<typename T1, typename T2>
-inline void check_valid_size(T1 current, T2 expected, const char * name, const char * funcname) {
+inline void check_valid_size(T1 current, T2 expected, const char * name, const char * funcname
+			, typename std::enable_if<std::is_signed<T1>::value == std::is_signed<T2>::value >::type* = 0) {
+
 	if (current != expected) {
 		throw std::invalid_argument(
 			std::string(name)

--- a/sodiumpp/sodiumpp.cpp
+++ b/sodiumpp/sodiumpp.cpp
@@ -364,7 +364,7 @@ std::string sodiumpp::bin2hex(const std::string& bytes) {
 }
 
 std::string sodiumpp::hex2bin(const std::string& bytes) {
-	check_valid_size( bytes.size() % 2 , 0 , "length must be even" , __func__ );
+	check_valid_size( bytes.size() % 2 , 0u , "length must be even" , __func__ );
 	std::string bin(bytes.size()/2, 0);
     size_t binlen;
     sodium_hex2bin(reinterpret_cast<unsigned char *>(&bin[0]), bin.size(), &bytes[0], bytes.size(), nullptr, &binlen, nullptr);


### PR DESCRIPTION
Otherwise bytes.size() is unsigned, and 0 is signed, which causes 

warning: comparison of integers of different signs: 'unsigned long' and 'int' [-Wsign-compare]
 if (current != expected) {

in instantiation of function template specialization 'sodiumpp::check_valid_size<unsigned long, int>' requested here
 check_valid_size( bytes.size() % 2 , 0 , "length must be even" , __func__ );
